### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/CGumboParser/gumbo.h
+++ b/Sources/CGumboParser/gumbo.h
@@ -84,7 +84,7 @@ typedef struct {
  * name. It also has efficiency benefits, by letting the parser work
  * with enums instead of strings.
  */
-typedef enum {
+typedef enum : size_t {
   GUMBO_TAG_HTML,
   GUMBO_TAG_HEAD,
   GUMBO_TAG_TITLE,

--- a/Sources/CGumboParser/insertion_mode.h
+++ b/Sources/CGumboParser/insertion_mode.h
@@ -4,7 +4,7 @@
 // https://html.spec.whatwg.org/multipage/parsing.html#insertion-mode
 // If new enum values are added, be sure to update the kTokenHandlers
 // dispatch table in parser.c.
-typedef enum {
+typedef enum : size_t {
   GUMBO_INSERTION_MODE_INITIAL,
   GUMBO_INSERTION_MODE_BEFORE_HTML,
   GUMBO_INSERTION_MODE_BEFORE_HEAD,

--- a/Sources/CGumboParser/parser.c
+++ b/Sources/CGumboParser/parser.c
@@ -4495,7 +4495,7 @@ HOT GumboOutput* gumbo_parse_with_options (
         break;
     }
     gumbo_debug (
-      "Handling %s token @%zu:%zu in state %u.\n",
+      "Handling %s token @%zu:%zu in state %zu.\n",
       (char*) token_type,
       token.position.line,
       token.position.column,

--- a/Sources/CGumboParser/svg_attrs.c
+++ b/Sources/CGumboParser/svg_attrs.c
@@ -49,7 +49,7 @@ hash (register const char *str, register size_t len)
       78, 78, 78, 78, 78, 78, 78, 78, 78, 78,
       78, 78, 78, 78, 78, 78, 78, 78
     };
-  register unsigned int hval = len;
+  register unsigned int hval = (unsigned int)len;
 
   switch (hval)
     {

--- a/Sources/CGumboParser/svg_tags.c
+++ b/Sources/CGumboParser/svg_tags.c
@@ -49,7 +49,7 @@ hash (register const char *str, register size_t len)
       43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
       43, 43, 43, 43, 43, 43, 43
     };
-  register unsigned int hval = len;
+  register unsigned int hval = (unsigned int)len;
 
   switch (hval)
     {

--- a/Sources/CGumboParser/tag_lookup.c
+++ b/Sources/CGumboParser/tag_lookup.c
@@ -49,7 +49,7 @@ hash (register const char *str, register size_t len)
       272, 272, 272, 272, 272, 272, 272, 272, 272, 272,
       272, 272, 272, 272, 272, 272, 272, 272, 272
     };
-  register unsigned int hval = len;
+  register unsigned int hval = (unsigned int)len;
 
   switch (hval)
     {


### PR DESCRIPTION
Previously, the project had 5 build warnings:

<img width="623" alt="Screenshot 2024-02-01 at 10 25 14 AM" src="https://github.com/gshahbazian/SwiftGumbo/assets/205658/204a58de-b4fb-4cfd-b90d-4af0f7908475">

This PR addresses these warnings.

* The first two are addressed by specifying that two enums should use an architecture-dependent size. This fixes the first two warnings when casting from `void *` to the enum type.
* The last 3 warnings are in generated code. Newer versions of the code generator appear to have [resolved](https://savannah.gnu.org/bugs/?func=detailitem&item_id=44887#options) these warnings, but for now, I'm just making the casts explicit. If we update the gumbo version in the future, hopefully we'll get regenerated code that also addresses these issues.